### PR TITLE
Fix GitHub Actions deployment path

### DIFF
--- a/.github/workflows/main_cestas-de-maria.yml
+++ b/.github/workflows/main_cestas-de-maria.yml
@@ -51,4 +51,4 @@ jobs:
           app-name: 'cestas-de-maria'
           slot-name: 'Production'
           publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_F2EC23C7E3914538A9150BC8C29731AA }}
-          package: .
+          package: .net-app


### PR DESCRIPTION
## Summary
- deploy the built app directory instead of workspace root

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a4675c4b0c832c9fd772b0d8f909ca