### PR TITLE
Improve JWT configuration error handling

### DIFF
--- a/CestasDeMaria.Presentation.Api/App_Start/Start.cs
+++ b/CestasDeMaria.Presentation.Api/App_Start/Start.cs
@@ -81,6 +81,25 @@ namespace CestasDeMaria.Presentation.Api.App_Start
 
         private void AddAuth()
         {
+            var jwtKey = _app.Configuration["Jwt:Key"] ?? Environment.GetEnvironmentVariable("JWT_KEY");
+            var jwtIssuer = _app.Configuration["Jwt:Issuer"] ?? Environment.GetEnvironmentVariable("JWT_ISSUER");
+            var jwtAudience = _app.Configuration["Jwt:Audience"] ?? Environment.GetEnvironmentVariable("JWT_AUDIENCE");
+
+            if (string.IsNullOrWhiteSpace(jwtKey))
+            {
+                throw new InvalidOperationException("JWT key is not configured.");
+            }
+
+            if (string.IsNullOrWhiteSpace(jwtIssuer))
+            {
+                throw new InvalidOperationException("JWT issuer is not configured.");
+            }
+
+            if (string.IsNullOrWhiteSpace(jwtAudience))
+            {
+                throw new InvalidOperationException("JWT audience is not configured.");
+            }
+
             _app.Services.AddAuthentication(options =>
             {
                 options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
@@ -91,9 +110,9 @@ namespace CestasDeMaria.Presentation.Api.App_Start
             {
                 options.TokenValidationParameters = new TokenValidationParameters
                 {
-                    ValidIssuer = _app.Configuration["Jwt:Issuer"],
-                    ValidAudience = _app.Configuration["Jwt:Audience"],
-                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_app.Configuration["Jwt:Key"])),
+                    ValidIssuer = jwtIssuer,
+                    ValidAudience = jwtAudience,
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey)),
                     ValidateIssuer = true,
                     ValidateAudience = true,
                     ValidateLifetime = false,

--- a/CestasDeMaria.Presentation.Api/CestasDeMaria.Presentation.Api.csproj
+++ b/CestasDeMaria.Presentation.Api/CestasDeMaria.Presentation.Api.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />

--- a/CestasDeMaria.Presentation.Api/Middleware/ErrorHandlingMiddleware.cs
+++ b/CestasDeMaria.Presentation.Api/Middleware/ErrorHandlingMiddleware.cs
@@ -20,11 +20,13 @@ namespace CestasDeMaria.Presentation.Api.Middleware
             }
             catch (Exception ex)
             {
+                var baseException = ex.GetBaseException();
+
                 var errorResponse = new
                 {
                     Message = "An error occurred",
-                    Exception = ex.Message,
-                    ex.StackTrace,
+                    Exception = baseException.Message,
+                    StackTrace = baseException.StackTrace,
                     Environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
                 };
 


### PR DESCRIPTION
## Summary
- Validate presence of JWT signing key, issuer, and audience, allowing fallback to JWT_KEY, JWT_ISSUER, and JWT_AUDIENCE environment variables
- Surface inner exception details in error middleware for easier diagnosis
- Reference System.IdentityModel.Tokens.Jwt package explicitly to ensure JWT assemblies are available at runtime

## Testing
- `apt-get update` *(fails: 403 Forbidden)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a480fea078832cb10287293b1aae53