### PR TITLE
Recalculate future weekly deliveries

### DIFF
--- a/CestasDeMaria.Infrastructure.Data/Repository/BasketdeliveriesRepository.cs
+++ b/CestasDeMaria.Infrastructure.Data/Repository/BasketdeliveriesRepository.cs
@@ -58,7 +58,13 @@ namespace CestasDeMaria.Infrastructure.Data.Repository
 
         public async Task<IEnumerable<Main>> GetByWeekAndYearNumberAsync(int week, int weekReference, int year, bool onlyValid, string[] include = null)
         {
-            var query = GetQueryable().Where(p => p.Weekofmonth.Equals(week) && p.Created.Year.Equals(year) && p.Families.DeliveryWeek.Equals(weekReference)).AsNoTracking();
+            var query = GetQueryable()
+                .Where(p => p.Weekofmonth.Equals(week) && p.Created.Year.Equals(year))
+                .AsNoTracking();
+
+            if (weekReference > 0)
+                query = query.Where(p => p.Families.DeliveryWeek.Equals(weekReference));
+
             if (onlyValid)
                 query = query.Where(p => p.Families.Familystatusid != 1 || (p.Families.Familystatusid == 1 && p.Deliverystatusid == 4));
 


### PR DESCRIPTION
## Summary
- remove stale basket deliveries when generating future schedules
- allow repository to fetch weekly deliveries without week filter

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a61580b010832c938bd4b918acd3d7